### PR TITLE
Support showing PDF in start-screen

### DIFF
--- a/app/models/Models.scala
+++ b/app/models/Models.scala
@@ -877,6 +877,7 @@ case class ElectionPresentation(
   extra_options: Option[ElectionExtra],
   show_login_link_on_home: Option[Boolean],
   conditional_questions: Option[Array[ConditionalQuestion]],
+  pdf_url: Option[Url],
 
   // Override translations for languages. Example:
   // {"en": {"avRegistration.forgotPassword": "Whatever"}}


### PR DESCRIPTION
# Changes

* Add `pdf_url`to the presentation section of the election. This means the url will be returned by the server to the client.