### PR TITLE
Removing XSS by not replying error string  onBadRequest

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -77,7 +77,7 @@ object Global extends WithFilters(LoggingFilter) with Response {
 
   override def onBadRequest(request: RequestHeader, error: String) = {
     Logger.warn(s"Bad Request: $error")
-    Future.successful(BadRequest(response("Bad Request: " + error)))
+    Future.successful(BadRequest(response("Bad Request")))
   }
 
   /** ensures the configuration property is set */


### PR DESCRIPTION
When making a request to the ballot-box, if the URL contains an invalid character the ballot-box automatically handles it with a response that replies with the contents of the invalid response. This can be considered an XSS threat, which is medium threat level.

Example:
- HTTP GET `https://demo.example.com/elections/api/election/21w5ad4%3cscript%3ealert(1)%3c/script%3emr7vd`
- Response:

```json
HTTP STATUS 400 response
{"date":"2022-12-27 09:17:47.869","payload":"Bad Request: Illegal character in path at index 21: /api/election/21w5ad4<script>alert(1)</script>mr7vd"}
````

This one-liner change fixes this potential issue by changing the `onBadRequest()` response to not replay the error string in the Bad Request response, resulting in the following response instead:

```json
HTTP STATUS 400 response
{"date":"2022-12-27 09:17:47.869","payload":"Bad Request"}
````