### PR TITLE
Always fix continue button to bottom 

### DIFF
--- a/app/models/Models.scala
+++ b/app/models/Models.scala
@@ -957,6 +957,7 @@ case class ElectionPresentation(
   election_board_ceremony: Option[Boolean], // default = false
   conditional_questions: Option[Array[ConditionalQuestion]],
   pdf_url: Option[Url],
+  anchor_continue_btn_to_bottom: Option[Boolean],
 
   // Override translations for languages. Example:
   // {"en": {"avRegistration.forgotPassword": "Whatever"}}


### PR DESCRIPTION
# Changes

* Add the parameter `anchor_continue_btn_to_bottom` to the presentation model. It should ideally be located on the extra properties of the presentation model but Scala has a limit of up to 32 case class properties.