### PR TITLE
Can't create election with checkable lists

### DIFF
--- a/app/models/Models.scala
+++ b/app/models/Models.scala
@@ -781,7 +781,7 @@ case class Question(
         .filter { answer => 
           answer.category.length > 0 &&
           answer.urls.filter {
-            url => (url.url != "true" || url.title != "isCategoryList")
+            url => (url.url == "true" && url.title == "isCategoryList")
           }.length == 0
         }
         .map { answer => answer.category }


### PR DESCRIPTION
When the extra option for questions `enable_checkable_lists` is used, we make a comparison to check that all categories used by answers are defined properly. However this check had an error and this PR fixes it.