### PR TITLE
Security updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
   ws,
   "com.typesafe.play" %% "play-slick" % "0.8.0",
   "org.postgresql" % "postgresql" % "42.4.3",
-  "org.bouncycastle" % "bcprov-jdk15on" % "1.69",
+  "org.bouncycastle" % "bcprov-jdk15to18" % "1.76",
   "com.googlecode.owasp-java-html-sanitizer" % "owasp-java-html-sanitizer" % "20211018.2",
   "commons-validator" % "commons-validator" % "1.4.1",
   "com.github.mumoshu" %% "play2-memcached-play23" % "0.7.0",

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.69</version>
+            <artifactId>bcprov-jdk15to18</artifactId>
+            <version>1.76</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/ballot-box/security/dependabot/6

Bumps from bcprov-jdk15on:1.69 to bcprov-jdk15to18:1.76 Fixing https://github.com/sequentech/ballot-box/security/dependabot/6